### PR TITLE
Loosen signature of T function

### DIFF
--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -188,7 +188,7 @@ comoving_volume_element_gpc3(c::AbstractCosmology, z) =
 
 # times
 
-T(c::AbstractCosmology, a0::Float64, a1::Float64) = ((q,_) = QuadGK.quadgk(x::Float64->x/a2E(c,x), a0, a1); q)
+T(c::AbstractCosmology, a0, a1) = ((q,_) = QuadGK.quadgk(x->x/a2E(c,x), a0, a1); q)
 age_gyr(c::AbstractCosmology, z) = hubble_time_gyr0(c)*T(c, 0., scale_factor(z))
 lookback_time_gyr(c::AbstractCosmology, z) = hubble_time_gyr0(c)*T(c, scale_factor(z), 1.)
 


### PR DESCRIPTION
This makes it possible to use `age_gyr` and `lookback_time_gyr` with arbitrary
types redshifts.