### PR TITLE
Require Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
 notifications:
     email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7-beta
 QuadGK 0.1.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module Cosmology
 
 using QuadGK

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Cosmology
-using Base.Test
+using Test
 
 function test_approx_eq_rtol(va, vb, rtol, astr, bstr)
     diff = maximum(abs(va - vb))


### PR DESCRIPTION
I'd suggest moving forward and dropping support also for Julia 0.6.  I think that we can replace the custom `@test_approx_eq_rtol a b rtol` with `@test a ≈ b rtol = rtol`.

There has been no change since last tagged version, just a fix to AppVeyor script and dropping support for Julia 0.5.  I don't think we need to tag a new release before merging this PR.