### PR TITLE
Use Unitful and UnitfulAstro to handle units

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installation
 To install the package:
 
 ```jlcon
-julia> Pkg.add("Cosmology")
+pkg> add Cosmology
 ```
 
 Then, to load into your session:
@@ -19,6 +19,9 @@ Then, to load into your session:
 ```jlcon
 julia> using Cosmology
 ```
+
+`Cosmology.jl` uses [`Unitful.jl`](https://github.com/ajkeller34/Unitful.jl) and
+[`UnitfulAstro.jl`](https://github.com/JuliaAstro/UnitfulAstro.jl) to handle units.
 
 Cosmological Models
 -------------------
@@ -79,19 +82,19 @@ Distances
 
 <table>
   <tr>
-    <td>angular_diameter_dist_mpc(cosmo,&nbsp;z)</td>
+    <td>angular_diameter_dist(cosmo,&nbsp;z)</td>
     <td>Ratio of an object's proper transverse size (in Mpc) to its angular size (in radians)</td>
   </tr>
   <tr>
-    <td>comoving_radial_dist_mpc(cosmo,&nbsp;z)</td>
+    <td>comoving_radial_dist(cosmo,&nbsp;z)</td>
     <td>Comoving radial distance to redshift z, in Mpc</td>
   </tr>
   <tr>
-    <td>comoving_volume_gpc3(cosmo,&nbsp;z)</td>
+    <td>comoving_volume(cosmo,&nbsp;z)</td>
     <td>Comoving volume out to redshift z, in Gpc<sup>3</sup></td>
   </tr>
   <tr>
-    <td>luminosity_dist_mpc(cosmo, z)</td>
+    <td>luminosity_dist(cosmo, z)</td>
     <td>Bolometric luminosity distance, in Mpc</td>
   </tr>
   <tr>
@@ -106,8 +109,8 @@ julia> using Cosmology
 julia> c = cosmology(OmegaM=0.26)
 FlatLCDM(0.69,0.7399122024007928,0.26,8.779759920715362e-5)
 
-julia> angular_diameter_dist_mpc(c, 1.2)
-1784.0089227105118
+julia> angular_diameter_dist(c, 1.2)
+1784.0089227105113 Mpc
 ```
 
 Times
@@ -115,11 +118,11 @@ Times
 
 <table>
   <tr>
-    <td>age_gyr(cosmo, z)</td>
+    <td>age(cosmo, z)</td>
     <td>Age of the universe at redshift z, in Gyr</td>
   </tr>
   <tr>
-    <td>lookback_time_gyr(cosmo, z)</td>
+    <td>lookback_time(cosmo, z)</td>
     <td>Difference between age at redshift 0 and age at redshift z, in Gyr</td>
   </tr>
 </table>
@@ -130,6 +133,6 @@ julia> using Cosmology
 julia> c = cosmology(OmegaM=0.26)
 FlatLCDM(0.69,0.7399122024007928,0.26,8.779759920715362e-5)
 
-julia> age_gyr(c, 1.2)
-5.445600787626434
+julia> age(c, 1.2)
+5.445600787626434 Gyr
 ```

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.7
 QuadGK 0.1.1
+Unitful 0.9.0
+UnitfulAstro 0.1.1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Cosmology
-using Test
+using Test, Unitful, UnitfulAstro
 
 # values from http://icosmos.co.uk/
 
@@ -8,81 +8,81 @@ age_rtol = 2e-4
 
 @testset "FlatLCDM" begin
     c = cosmology(h=0.7, OmegaM=0.3, OmegaR=0)
-    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1651.9145 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3303.829 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 151.0571 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6607.6579 rtol = dist_rtol
+    @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1651.9145u"Mpc" rtol = dist_rtol
+    @test comoving_radial_dist(c,1,rtol=dist_rtol) ≈ 3303.829u"Mpc" rtol = dist_rtol
+    @test comoving_volume(c,1,rtol=dist_rtol) ≈ 151.0571u"Gpc^3" rtol = dist_rtol
+    @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6607.6579u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.1002 rtol = dist_rtol
-    @test age_gyr(c,0,rtol=age_rtol) ≈ 13.4694 rtol = age_rtol
-    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.7527 rtol = age_rtol
-    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 13.4694-5.7527 rtol = age_rtol
+    @test age(c,0,rtol=age_rtol) ≈ 13.4694u"Gyr" rtol = age_rtol
+    @test age(c,1,rtol=age_rtol) ≈ 5.7527u"Gyr" rtol = age_rtol
+    @test lookback_time(c,1,rtol=age_rtol) ≈ (13.4694-5.7527)u"Gyr" rtol = age_rtol
 end
 
 @testset "OpenLCDM" begin
     c = cosmology(h=0.7, OmegaK=0.1, OmegaM=0.3, OmegaR=0)
-    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1619.9588 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3209.784 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 140.0856 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6479.8352 rtol = dist_rtol
+    @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1619.9588u"Mpc" rtol = dist_rtol
+    @test comoving_radial_dist(c,1,rtol=dist_rtol) ≈ 3209.784u"Mpc" rtol = dist_rtol
+    @test comoving_volume(c,1,rtol=dist_rtol) ≈ 140.0856u"Gpc^3" rtol = dist_rtol
+    @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6479.8352u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.0578 rtol = dist_rtol
-    @test age_gyr(c,0,rtol=age_rtol) ≈ 13.064 rtol = age_rtol
-    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.5466 rtol = age_rtol
-    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 13.064-5.5466 rtol = age_rtol
+    @test age(c,0,rtol=age_rtol) ≈ 13.064u"Gyr" rtol = age_rtol
+    @test age(c,1,rtol=age_rtol) ≈ 5.5466u"Gyr" rtol = age_rtol
+    @test lookback_time(c,1,rtol=age_rtol) ≈ (13.064-5.5466)u"Gyr" rtol = age_rtol
 end
 
 @testset "ClosedLCDM" begin
     c = cosmology(h=0.7, OmegaK=-0.1, OmegaM=0.3, OmegaR=0)
-    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1686.5272 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3408.937 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 163.8479 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6746.1088 rtol = dist_rtol
+    @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1686.5272u"Mpc" rtol = dist_rtol
+    @test comoving_radial_dist(c,1,rtol=dist_rtol) ≈ 3408.937u"Mpc" rtol = dist_rtol
+    @test comoving_volume(c,1,rtol=dist_rtol) ≈ 163.8479u"Gpc^3" rtol = dist_rtol
+    @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6746.1088u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.1453 rtol = dist_rtol
-    @test age_gyr(c,0,rtol=age_rtol) ≈ 13.925 rtol = age_rtol
-    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.9868 rtol = age_rtol
-    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 13.925-5.9868 rtol = age_rtol
+    @test age(c,0,rtol=age_rtol) ≈ 13.925u"Gyr" rtol = age_rtol
+    @test age(c,1,rtol=age_rtol) ≈ 5.9868u"Gyr" rtol = age_rtol
+    @test lookback_time(c,1,rtol=age_rtol) ≈ (13.925-5.9868)u"Gyr" rtol = age_rtol
 end
 
 @testset "FlatWCDM" begin
     c = cosmology(h=0.7, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1612.0585 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3224.1169 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 140.3851 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6448.2338 rtol = dist_rtol
+    @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1612.0585u"Mpc" rtol = dist_rtol
+    @test comoving_radial_dist(c,1,rtol=dist_rtol) ≈ 3224.1169u"Mpc" rtol = dist_rtol
+    @test comoving_volume(c,1,rtol=dist_rtol) ≈ 140.3851u"Gpc^3" rtol = dist_rtol
+    @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6448.2338u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.0472 rtol = dist_rtol
-    @test age_gyr(c,0,rtol=age_rtol) ≈ 13.1915 rtol = age_rtol
-    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.6464 rtol = age_rtol
-    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 13.1915-5.6464 rtol = age_rtol
+    @test age(c,0,rtol=age_rtol) ≈ 13.1915u"Gyr" rtol = age_rtol
+    @test age(c,1,rtol=age_rtol) ≈ 5.6464u"Gyr" rtol = age_rtol
+    @test lookback_time(c,1,rtol=age_rtol) ≈ (13.1915-5.6464)u"Gyr" rtol = age_rtol
 end
 
 @testset "OpenWCDM" begin
     c = cosmology(h=0.7, OmegaK=0.1, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1588.0181 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3147.6227 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 132.0466 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6352.0723 rtol = dist_rtol
+    @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1588.0181u"Mpc" rtol = dist_rtol
+    @test comoving_radial_dist(c,rtol=dist_rtol,1) ≈ 3147.6227u"Mpc" rtol = dist_rtol
+    @test comoving_volume(c,1,rtol=dist_rtol) ≈ 132.0466u"Gpc^3" rtol = dist_rtol
+    @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6352.0723u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.0146 rtol = dist_rtol
-    @test age_gyr(c,0,rtol=age_rtol) ≈ 12.8488 rtol = age_rtol
-    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.4659 rtol = age_rtol
-    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 12.8488-5.4659 rtol = age_rtol
+    @test age(c,0,rtol=age_rtol) ≈ 12.8488u"Gyr" rtol = age_rtol
+    @test age(c,1,rtol=age_rtol) ≈ 5.4659u"Gyr" rtol = age_rtol
+    @test lookback_time(c,1,rtol=age_rtol) ≈ (12.8488-5.4659)u"Gyr" rtol = age_rtol
 end
 
 @testset "ClosedWCDM" begin
     c = cosmology(h=0.7, OmegaK=-0.1, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1637.5993 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3307.9932 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 149.8301 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6550.3973 rtol = dist_rtol
+    @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1637.5993u"Mpc" rtol = dist_rtol
+    @test comoving_radial_dist(c,1,rtol=dist_rtol) ≈ 3307.9932u"Mpc" rtol = dist_rtol
+    @test comoving_volume(c,1,rtol=dist_rtol) ≈ 149.8301u"Gpc^3" rtol = dist_rtol
+    @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6550.3973u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.0813 rtol = dist_rtol
-    @test age_gyr(c,0,rtol=age_rtol) ≈ 13.5702 rtol = age_rtol
-    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.8482 rtol = age_rtol
-    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 13.5702-5.8482 rtol = age_rtol
+    @test age(c,0,rtol=age_rtol) ≈ 13.5702u"Gyr" rtol = age_rtol
+    @test age(c,1,rtol=age_rtol) ≈ 5.8482u"Gyr" rtol = age_rtol
+    @test lookback_time(c,1,rtol=age_rtol) ≈ (13.5702-5.8482)u"Gyr" rtol = age_rtol
 end
 
 @testset "Non-Float64" begin
     # Test that FlatLCDM works with non-Float64 (BigFloat in this example)
     c = cosmology(h=0.7, OmegaM=big(0.3), OmegaR=0)
-    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1651.9145 rtol = dist_rtol
+    @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1651.9145u"Mpc" rtol = dist_rtol
     # Test that FlatWCDM works with non-Float64 (BigFloat in this example)
     c = cosmology(h=big(0.7), OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1612.0585 rtol = dist_rtol
+    @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1612.0585u"Mpc" rtol = dist_rtol
 end


### PR DESCRIPTION
I went bold with this change that I've been wishing for a long time.

It's marked as WIP because the last stable version of Unitful is not fully adapted to Julia 0.7 (precompilation is broken, for example), the latest dev version solves some issues.

I didn't perform extended benchmarks, but performance should basically remain the same, which is really cool.  On master:
```julia
julia> using BenchmarkTools, Cosmology

julia> c = cosmology(h=0.7, OmegaM=0.3, OmegaR=0)
Cosmology.FlatLCDM{Float64}(0.7, 0.7, 0.3, 0.0)

julia> lookback_time_gyr(c, 1)
7.715508846944272

julia> @benchmark lookback_time_gyr($c, 1)
BenchmarkTools.Trial: 
  memory estimate:  736 bytes
  allocs estimate:  26
  --------------
  minimum time:     1.640 μs (0.00% GC)
  median time:      1.694 μs (0.00% GC)
  mean time:        2.359 μs (25.20% GC)
  maximum time:     4.423 ms (99.93% GC)
  --------------
  samples:          10000
  evals/sample:     10

julia> @benchmark comoving_volume_gpc3($c, 1)
BenchmarkTools.Trial: 
  memory estimate:  784 bytes
  allocs estimate:  29
  --------------
  minimum time:     1.720 μs (0.00% GC)
  median time:      1.788 μs (0.00% GC)
  mean time:        2.447 μs (24.99% GC)
  maximum time:     4.494 ms (99.89% GC)
  --------------
  samples:          10000
  evals/sample:     10
```
With this PR:
```julia
julia> @benchmark lookback_time($c, 1)
BenchmarkTools.Trial: 
  memory estimate:  736 bytes
  allocs estimate:  26
  --------------
  minimum time:     1.638 μs (0.00% GC)
  median time:      1.765 μs (0.00% GC)
  mean time:        2.440 μs (26.49% GC)
  maximum time:     4.778 ms (99.93% GC)
  --------------
  samples:          10000
  evals/sample:     10

julia> @benchmark comoving_volume($c, 1)
BenchmarkTools.Trial: 
  memory estimate:  784 bytes
  allocs estimate:  29
  --------------
  minimum time:     1.703 μs (0.00% GC)
  median time:      1.792 μs (0.00% GC)
  mean time:        2.468 μs (25.63% GC)
  maximum time:     4.705 ms (99.91% GC)
  --------------
  samples:          10000
  evals/sample:     10
```

One possible extension is to add a first optional argument with the output unit, something like:
```julia
julia> lookback_time(c, 1)
7.715508846944272 Gyr

julia> lookback_time(u"yr", c, 1)
7.715508846944272e9 yr
```