### PR TITLE
Pass optional keyword arguments to quadgk

### DIFF
--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -143,54 +143,55 @@ hubble_time_gyr(c::AbstractCosmology, z) = hubble_time_gyr0(c)/E(c,z)
 
 # distances
 
-Z(c::AbstractCosmology, z::Real) = ((q,_) = QuadGK.quadgk(a::Float64->1.0/a2E(c,a), scale_factor(z), 1); q)
+Z(c::AbstractCosmology, z::Real; kws...) =
+    QuadGK.quadgk(a::Float64->1.0/a2E(c,a), scale_factor(z), 1; kws...)[1]
 
-comoving_radial_dist_mpc(c::AbstractCosmology, z) = hubble_dist_mpc0(c)*Z(c, z)
+comoving_radial_dist_mpc(c::AbstractCosmology, z; kws...) = hubble_dist_mpc0(c)*Z(c, z; kws...)
 
-comoving_transverse_dist_mpc(c::AbstractFlatCosmology, z) =
-    comoving_radial_dist_mpc(c, z)
-function comoving_transverse_dist_mpc(c::AbstractOpenCosmology, z)
+comoving_transverse_dist_mpc(c::AbstractFlatCosmology, z; kws...) =
+    comoving_radial_dist_mpc(c, z; kws...)
+function comoving_transverse_dist_mpc(c::AbstractOpenCosmology, z; kws...)
     sqrtok = sqrt(c.Ω_k)
-    hubble_dist_mpc0(c)*sinh(sqrtok*Z(c,z))/sqrtok
+    hubble_dist_mpc0(c)*sinh(sqrtok*Z(c,z; kws...))/sqrtok
 end
-function comoving_transverse_dist_mpc(c::AbstractClosedCosmology, z)
+function comoving_transverse_dist_mpc(c::AbstractClosedCosmology, z; kws...)
     sqrtok = sqrt(abs(c.Ω_k))
-    hubble_dist_mpc0(c)*sin(sqrtok*Z(c,z))/sqrtok
+    hubble_dist_mpc0(c)*sin(sqrtok*Z(c,z; kws...))/sqrtok
 end
 
-angular_diameter_dist_mpc(c::AbstractCosmology, z) =
-    comoving_transverse_dist_mpc(c, z)/(1 + z)
+angular_diameter_dist_mpc(c::AbstractCosmology, z; kws...) =
+    comoving_transverse_dist_mpc(c, z; kws...)/(1 + z)
 
-luminosity_dist_mpc(c::AbstractCosmology, z) =
-    comoving_transverse_dist_mpc(c, z)*(1 + z)
+luminosity_dist_mpc(c::AbstractCosmology, z; kws...) =
+    comoving_transverse_dist_mpc(c, z; kws...)*(1 + z)
 
-distmod(c::AbstractCosmology, z) =
-    5.0 * log10(luminosity_dist_mpc(c, z)) + 25.0
+distmod(c::AbstractCosmology, z; kws...) =
+    5.0 * log10(luminosity_dist_mpc(c, z; kws...)) + 25.0
 
 # volumes
 
-comoving_volume_gpc3(c::AbstractFlatCosmology, z) =
-    (4pi/3)*(comoving_radial_dist_mpc(c,z)*1e-3)^3
-function comoving_volume_gpc3(c::AbstractOpenCosmology, z)
+comoving_volume_gpc3(c::AbstractFlatCosmology, z; kws...) =
+    (4pi/3)*(comoving_radial_dist_mpc(c,z; kws...)*1e-3)^3
+function comoving_volume_gpc3(c::AbstractOpenCosmology, z; kws...)
     DH = hubble_dist_mpc0(c)
-    x = comoving_transverse_dist_mpc(c,z)/DH
+    x = comoving_transverse_dist_mpc(c,z; kws...)/DH
     sqrtok = sqrt(c.Ω_k)
     2pi*(DH*1e-3)^3*(x*sqrt(1. + c.Ω_k*x^2) - asinh(sqrtok*x)/sqrtok)/c.Ω_k
 end
-function comoving_volume_gpc3(c::AbstractClosedCosmology, z)
+function comoving_volume_gpc3(c::AbstractClosedCosmology, z; kws...)
     DH = hubble_dist_mpc0(c)
-    x = comoving_transverse_dist_mpc(c,z)/DH
+    x = comoving_transverse_dist_mpc(c,z; kws...)/DH
     sqrtok = sqrt(abs(c.Ω_k))
     2pi*(DH*1e-3)^3*(x*sqrt(1. + c.Ω_k*x^2) - asin(sqrtok*x)/sqrtok)/c.Ω_k
 end
 
-comoving_volume_element_gpc3(c::AbstractCosmology, z) =
-    1e-9*hubble_dist_mpc0(c,z)*angular_diameter_dist_mpc(c,z)^2/a2E(c,scale_factor(z))
+comoving_volume_element_gpc3(c::AbstractCosmology, z; kws...) =
+    1e-9*hubble_dist_mpc0(c,z)*angular_diameter_dist_mpc(c,z; kws...)^2/a2E(c,scale_factor(z))
 
 # times
 
-T(c::AbstractCosmology, a0, a1) = ((q,_) = QuadGK.quadgk(x->x/a2E(c,x), a0, a1); q)
-age_gyr(c::AbstractCosmology, z) = hubble_time_gyr0(c)*T(c, 0., scale_factor(z))
-lookback_time_gyr(c::AbstractCosmology, z) = hubble_time_gyr0(c)*T(c, scale_factor(z), 1.)
+T(c::AbstractCosmology, a0, a1; kws...) = QuadGK.quadgk(x->x/a2E(c,x), a0, a1; kws...)[1]
+age_gyr(c::AbstractCosmology, z; kws...) = hubble_time_gyr0(c)*T(c, 0., scale_factor(z); kws...)
+lookback_time_gyr(c::AbstractCosmology, z; kws...) = hubble_time_gyr0(c)*T(c, scale_factor(z), 1.; kws...)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,91 +1,88 @@
 using Cosmology
 using Test
 
-function test_approx_eq_rtol(va, vb, rtol, astr, bstr)
-    diff = maximum(abs(va - vb))
-    tol = rtol*max(maximum(abs(va)), maximum(abs(vb)))
-    if diff > tol
-        sdiff = string("|", astr, " - ", bstr, "| <= ", tol)
-        error("assertion failed: ", sdiff,
-              "\n  ", astr, " = ", va,
-              "\n  ", bstr, " = ", vb,
-              "\n  difference = ", diff, " > ", tol)
-    end
-end
-
-macro test_approx_eq_rtol(a, b, c)
-    :(test_approx_eq_rtol($(esc(a)), $(esc(b)), $(esc(c)), $(string(a)), $(string(b))))
-end
-
 # values from http://icosmos.co.uk/
 
 dist_rtol = 1e-6
 age_rtol = 2e-4
 
-c = cosmology(h=0.7, OmegaM=0.3, OmegaR=0)
-@test_approx_eq_rtol angular_diameter_dist_mpc(c,1) 1651.9145 dist_rtol
-@test_approx_eq_rtol comoving_radial_dist_mpc(c,1) 3303.829 dist_rtol
-@test_approx_eq_rtol comoving_volume_gpc3(c,1) 151.0571 dist_rtol
-@test_approx_eq_rtol luminosity_dist_mpc(c,1) 6607.6579 dist_rtol
-@test_approx_eq_rtol distmod(c,1) 44.1002 dist_rtol
-@test_approx_eq_rtol age_gyr(c,0) 13.4694 age_rtol
-@test_approx_eq_rtol age_gyr(c,1) 5.7527 age_rtol
-@test_approx_eq_rtol lookback_time_gyr(c,1) 13.4694-5.7527 age_rtol
+@testset "FlatLCDM" begin
+    c = cosmology(h=0.7, OmegaM=0.3, OmegaR=0)
+    @test angular_diameter_dist_mpc(c,1) ≈ 1651.9145 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1) ≈ 3303.829 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1) ≈ 151.0571 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1) ≈ 6607.6579 rtol = dist_rtol
+    @test distmod(c,1) ≈ 44.1002 rtol = dist_rtol
+    @test age_gyr(c,0) ≈ 13.4694 rtol = age_rtol
+    @test age_gyr(c,1) ≈ 5.7527 rtol = age_rtol
+    @test lookback_time_gyr(c,1) ≈ 13.4694-5.7527 rtol = age_rtol
+end
 
-c = cosmology(h=0.7, OmegaK=0.1, OmegaM=0.3, OmegaR=0)
-@test_approx_eq_rtol angular_diameter_dist_mpc(c,1) 1619.9588 dist_rtol
-@test_approx_eq_rtol comoving_radial_dist_mpc(c,1) 3209.784 dist_rtol
-@test_approx_eq_rtol comoving_volume_gpc3(c,1) 140.0856 dist_rtol
-@test_approx_eq_rtol luminosity_dist_mpc(c,1) 6479.8352 dist_rtol
-@test_approx_eq_rtol distmod(c,1) 44.0578 dist_rtol
-@test_approx_eq_rtol age_gyr(c,0) 13.064 age_rtol
-@test_approx_eq_rtol age_gyr(c,1) 5.5466 age_rtol
-@test_approx_eq_rtol lookback_time_gyr(c,1) 13.064-5.5466 age_rtol
+@testset "OpenLCDM" begin
+    c = cosmology(h=0.7, OmegaK=0.1, OmegaM=0.3, OmegaR=0)
+    @test angular_diameter_dist_mpc(c,1) ≈ 1619.9588 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1) ≈ 3209.784 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1) ≈ 140.0856 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1) ≈ 6479.8352 rtol = dist_rtol
+    @test distmod(c,1) ≈ 44.0578 rtol = dist_rtol
+    @test age_gyr(c,0) ≈ 13.064 rtol = age_rtol
+    @test age_gyr(c,1) ≈ 5.5466 rtol = age_rtol
+    @test lookback_time_gyr(c,1) ≈ 13.064-5.5466 rtol = age_rtol
+end
 
-c = cosmology(h=0.7, OmegaK=-0.1, OmegaM=0.3, OmegaR=0)
-@test_approx_eq_rtol angular_diameter_dist_mpc(c,1) 1686.5272 dist_rtol
-@test_approx_eq_rtol comoving_radial_dist_mpc(c,1) 3408.937 dist_rtol
-@test_approx_eq_rtol comoving_volume_gpc3(c,1) 163.8479 dist_rtol
-@test_approx_eq_rtol luminosity_dist_mpc(c,1) 6746.1088 dist_rtol
-@test_approx_eq_rtol distmod(c,1) 44.1453 dist_rtol
-@test_approx_eq_rtol age_gyr(c,0) 13.925 age_rtol
-@test_approx_eq_rtol age_gyr(c,1) 5.9868 age_rtol
-@test_approx_eq_rtol lookback_time_gyr(c,1) 13.925-5.9868 age_rtol
+@testset "ClosedLCDM" begin
+    c = cosmology(h=0.7, OmegaK=-0.1, OmegaM=0.3, OmegaR=0)
+    @test angular_diameter_dist_mpc(c,1) ≈ 1686.5272 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1) ≈ 3408.937 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1) ≈ 163.8479 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1) ≈ 6746.1088 rtol = dist_rtol
+    @test distmod(c,1) ≈ 44.1453 rtol = dist_rtol
+    @test age_gyr(c,0) ≈ 13.925 rtol = age_rtol
+    @test age_gyr(c,1) ≈ 5.9868 rtol = age_rtol
+    @test lookback_time_gyr(c,1) ≈ 13.925-5.9868 rtol = age_rtol
+end
 
-c = cosmology(h=0.7, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-@test_approx_eq_rtol angular_diameter_dist_mpc(c,1) 1612.0585 dist_rtol
-@test_approx_eq_rtol comoving_radial_dist_mpc(c,1) 3224.1169 dist_rtol
-@test_approx_eq_rtol comoving_volume_gpc3(c,1) 140.3851 dist_rtol
-@test_approx_eq_rtol luminosity_dist_mpc(c,1) 6448.2338 dist_rtol
-@test_approx_eq_rtol distmod(c,1) 44.0472 dist_rtol
-@test_approx_eq_rtol age_gyr(c,0) 13.1915 age_rtol
-@test_approx_eq_rtol age_gyr(c,1) 5.6464 age_rtol
-@test_approx_eq_rtol lookback_time_gyr(c,1) 13.1915-5.6464 age_rtol
+@testset "FlatWCDM" begin
+    c = cosmology(h=0.7, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
+    @test angular_diameter_dist_mpc(c,1) ≈ 1612.0585 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1) ≈ 3224.1169 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1) ≈ 140.3851 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1) ≈ 6448.2338 rtol = dist_rtol
+    @test distmod(c,1) ≈ 44.0472 rtol = dist_rtol
+    @test age_gyr(c,0) ≈ 13.1915 rtol = age_rtol
+    @test age_gyr(c,1) ≈ 5.6464 rtol = age_rtol
+    @test lookback_time_gyr(c,1) ≈ 13.1915-5.6464 rtol = age_rtol
+end
 
-c = cosmology(h=0.7, OmegaK=0.1, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-@test_approx_eq_rtol angular_diameter_dist_mpc(c,1) 1588.0181 dist_rtol
-@test_approx_eq_rtol comoving_radial_dist_mpc(c,1) 3147.6227 dist_rtol
-@test_approx_eq_rtol comoving_volume_gpc3(c,1) 132.0466 dist_rtol
-@test_approx_eq_rtol luminosity_dist_mpc(c,1) 6352.0723 dist_rtol
-@test_approx_eq_rtol distmod(c,1) 44.0146 dist_rtol
-@test_approx_eq_rtol age_gyr(c,0) 12.8488 age_rtol
-@test_approx_eq_rtol age_gyr(c,1) 5.4659 age_rtol
-@test_approx_eq_rtol lookback_time_gyr(c,1) 12.8488-5.4659 age_rtol
+@testset "OpenWCDM" begin
+    c = cosmology(h=0.7, OmegaK=0.1, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
+    @test angular_diameter_dist_mpc(c,1) ≈ 1588.0181 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1) ≈ 3147.6227 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1) ≈ 132.0466 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1) ≈ 6352.0723 rtol = dist_rtol
+    @test distmod(c,1) ≈ 44.0146 rtol = dist_rtol
+    @test age_gyr(c,0) ≈ 12.8488 rtol = age_rtol
+    @test age_gyr(c,1) ≈ 5.4659 rtol = age_rtol
+    @test lookback_time_gyr(c,1) ≈ 12.8488-5.4659 rtol = age_rtol
+end
 
-c = cosmology(h=0.7, OmegaK=-0.1, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-@test_approx_eq_rtol angular_diameter_dist_mpc(c,1) 1637.5993 dist_rtol
-@test_approx_eq_rtol comoving_radial_dist_mpc(c,1) 3307.9932 dist_rtol
-@test_approx_eq_rtol comoving_volume_gpc3(c,1) 149.8301 dist_rtol
-@test_approx_eq_rtol luminosity_dist_mpc(c,1) 6550.3973 dist_rtol
-@test_approx_eq_rtol distmod(c,1) 44.0813 dist_rtol
-@test_approx_eq_rtol age_gyr(c,0) 13.5702 age_rtol
-@test_approx_eq_rtol age_gyr(c,1) 5.8482 age_rtol
-@test_approx_eq_rtol lookback_time_gyr(c,1) 13.5702-5.8482 age_rtol
+@testset "ClosedWCDM" begin
+    c = cosmology(h=0.7, OmegaK=-0.1, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
+    @test angular_diameter_dist_mpc(c,1) ≈ 1637.5993 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1) ≈ 3307.9932 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1) ≈ 149.8301 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1) ≈ 6550.3973 rtol = dist_rtol
+    @test distmod(c,1) ≈ 44.0813 rtol = dist_rtol
+    @test age_gyr(c,0) ≈ 13.5702 rtol = age_rtol
+    @test age_gyr(c,1) ≈ 5.8482 rtol = age_rtol
+    @test lookback_time_gyr(c,1) ≈ 13.5702-5.8482 rtol = age_rtol
+end
 
-# Test that FlatLCDM works with non-Float64 (BigFloat in this example)
-c = cosmology(h=0.7, OmegaM=big(0.3), OmegaR=0)
-@test_approx_eq_rtol angular_diameter_dist_mpc(c,1) 1651.9145 dist_rtol
-
-# Test that FlatWCDM works with non-Float64 (BigFloat in this example)
-c = cosmology(h=big(0.7), OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-@test_approx_eq_rtol angular_diameter_dist_mpc(c,1) 1612.0585 dist_rtol
+@testset "Non-Float64" begin
+    # Test that FlatLCDM works with non-Float64 (BigFloat in this example)
+    c = cosmology(h=0.7, OmegaM=big(0.3), OmegaR=0)
+    @test angular_diameter_dist_mpc(c,1) ≈ 1651.9145 rtol = dist_rtol
+    # Test that FlatWCDM works with non-Float64 (BigFloat in this example)
+    c = cosmology(h=big(0.7), OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
+    @test angular_diameter_dist_mpc(c,1) ≈ 1612.0585 rtol = dist_rtol
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,81 +8,81 @@ age_rtol = 2e-4
 
 @testset "FlatLCDM" begin
     c = cosmology(h=0.7, OmegaM=0.3, OmegaR=0)
-    @test angular_diameter_dist_mpc(c,1) ≈ 1651.9145 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1) ≈ 3303.829 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1) ≈ 151.0571 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1) ≈ 6607.6579 rtol = dist_rtol
-    @test distmod(c,1) ≈ 44.1002 rtol = dist_rtol
-    @test age_gyr(c,0) ≈ 13.4694 rtol = age_rtol
-    @test age_gyr(c,1) ≈ 5.7527 rtol = age_rtol
-    @test lookback_time_gyr(c,1) ≈ 13.4694-5.7527 rtol = age_rtol
+    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1651.9145 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3303.829 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 151.0571 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6607.6579 rtol = dist_rtol
+    @test distmod(c,1,rtol=dist_rtol) ≈ 44.1002 rtol = dist_rtol
+    @test age_gyr(c,0,rtol=age_rtol) ≈ 13.4694 rtol = age_rtol
+    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.7527 rtol = age_rtol
+    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 13.4694-5.7527 rtol = age_rtol
 end
 
 @testset "OpenLCDM" begin
     c = cosmology(h=0.7, OmegaK=0.1, OmegaM=0.3, OmegaR=0)
-    @test angular_diameter_dist_mpc(c,1) ≈ 1619.9588 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1) ≈ 3209.784 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1) ≈ 140.0856 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1) ≈ 6479.8352 rtol = dist_rtol
-    @test distmod(c,1) ≈ 44.0578 rtol = dist_rtol
-    @test age_gyr(c,0) ≈ 13.064 rtol = age_rtol
-    @test age_gyr(c,1) ≈ 5.5466 rtol = age_rtol
-    @test lookback_time_gyr(c,1) ≈ 13.064-5.5466 rtol = age_rtol
+    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1619.9588 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3209.784 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 140.0856 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6479.8352 rtol = dist_rtol
+    @test distmod(c,1,rtol=dist_rtol) ≈ 44.0578 rtol = dist_rtol
+    @test age_gyr(c,0,rtol=age_rtol) ≈ 13.064 rtol = age_rtol
+    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.5466 rtol = age_rtol
+    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 13.064-5.5466 rtol = age_rtol
 end
 
 @testset "ClosedLCDM" begin
     c = cosmology(h=0.7, OmegaK=-0.1, OmegaM=0.3, OmegaR=0)
-    @test angular_diameter_dist_mpc(c,1) ≈ 1686.5272 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1) ≈ 3408.937 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1) ≈ 163.8479 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1) ≈ 6746.1088 rtol = dist_rtol
-    @test distmod(c,1) ≈ 44.1453 rtol = dist_rtol
-    @test age_gyr(c,0) ≈ 13.925 rtol = age_rtol
-    @test age_gyr(c,1) ≈ 5.9868 rtol = age_rtol
-    @test lookback_time_gyr(c,1) ≈ 13.925-5.9868 rtol = age_rtol
+    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1686.5272 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3408.937 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 163.8479 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6746.1088 rtol = dist_rtol
+    @test distmod(c,1,rtol=dist_rtol) ≈ 44.1453 rtol = dist_rtol
+    @test age_gyr(c,0,rtol=age_rtol) ≈ 13.925 rtol = age_rtol
+    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.9868 rtol = age_rtol
+    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 13.925-5.9868 rtol = age_rtol
 end
 
 @testset "FlatWCDM" begin
     c = cosmology(h=0.7, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-    @test angular_diameter_dist_mpc(c,1) ≈ 1612.0585 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1) ≈ 3224.1169 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1) ≈ 140.3851 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1) ≈ 6448.2338 rtol = dist_rtol
-    @test distmod(c,1) ≈ 44.0472 rtol = dist_rtol
-    @test age_gyr(c,0) ≈ 13.1915 rtol = age_rtol
-    @test age_gyr(c,1) ≈ 5.6464 rtol = age_rtol
-    @test lookback_time_gyr(c,1) ≈ 13.1915-5.6464 rtol = age_rtol
+    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1612.0585 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3224.1169 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 140.3851 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6448.2338 rtol = dist_rtol
+    @test distmod(c,1,rtol=dist_rtol) ≈ 44.0472 rtol = dist_rtol
+    @test age_gyr(c,0,rtol=age_rtol) ≈ 13.1915 rtol = age_rtol
+    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.6464 rtol = age_rtol
+    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 13.1915-5.6464 rtol = age_rtol
 end
 
 @testset "OpenWCDM" begin
     c = cosmology(h=0.7, OmegaK=0.1, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-    @test angular_diameter_dist_mpc(c,1) ≈ 1588.0181 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1) ≈ 3147.6227 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1) ≈ 132.0466 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1) ≈ 6352.0723 rtol = dist_rtol
-    @test distmod(c,1) ≈ 44.0146 rtol = dist_rtol
-    @test age_gyr(c,0) ≈ 12.8488 rtol = age_rtol
-    @test age_gyr(c,1) ≈ 5.4659 rtol = age_rtol
-    @test lookback_time_gyr(c,1) ≈ 12.8488-5.4659 rtol = age_rtol
+    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1588.0181 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3147.6227 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 132.0466 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6352.0723 rtol = dist_rtol
+    @test distmod(c,1,rtol=dist_rtol) ≈ 44.0146 rtol = dist_rtol
+    @test age_gyr(c,0,rtol=age_rtol) ≈ 12.8488 rtol = age_rtol
+    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.4659 rtol = age_rtol
+    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 12.8488-5.4659 rtol = age_rtol
 end
 
 @testset "ClosedWCDM" begin
     c = cosmology(h=0.7, OmegaK=-0.1, OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-    @test angular_diameter_dist_mpc(c,1) ≈ 1637.5993 rtol = dist_rtol
-    @test comoving_radial_dist_mpc(c,1) ≈ 3307.9932 rtol = dist_rtol
-    @test comoving_volume_gpc3(c,1) ≈ 149.8301 rtol = dist_rtol
-    @test luminosity_dist_mpc(c,1) ≈ 6550.3973 rtol = dist_rtol
-    @test distmod(c,1) ≈ 44.0813 rtol = dist_rtol
-    @test age_gyr(c,0) ≈ 13.5702 rtol = age_rtol
-    @test age_gyr(c,1) ≈ 5.8482 rtol = age_rtol
-    @test lookback_time_gyr(c,1) ≈ 13.5702-5.8482 rtol = age_rtol
+    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1637.5993 rtol = dist_rtol
+    @test comoving_radial_dist_mpc(c,1,rtol=dist_rtol) ≈ 3307.9932 rtol = dist_rtol
+    @test comoving_volume_gpc3(c,1,rtol=dist_rtol) ≈ 149.8301 rtol = dist_rtol
+    @test luminosity_dist_mpc(c,1,rtol=dist_rtol) ≈ 6550.3973 rtol = dist_rtol
+    @test distmod(c,1,rtol=dist_rtol) ≈ 44.0813 rtol = dist_rtol
+    @test age_gyr(c,0,rtol=age_rtol) ≈ 13.5702 rtol = age_rtol
+    @test age_gyr(c,1,rtol=age_rtol) ≈ 5.8482 rtol = age_rtol
+    @test lookback_time_gyr(c,1,rtol=age_rtol) ≈ 13.5702-5.8482 rtol = age_rtol
 end
 
 @testset "Non-Float64" begin
     # Test that FlatLCDM works with non-Float64 (BigFloat in this example)
     c = cosmology(h=0.7, OmegaM=big(0.3), OmegaR=0)
-    @test angular_diameter_dist_mpc(c,1) ≈ 1651.9145 rtol = dist_rtol
+    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1651.9145 rtol = dist_rtol
     # Test that FlatWCDM works with non-Float64 (BigFloat in this example)
     c = cosmology(h=big(0.7), OmegaM=0.3, OmegaR=0, w0=-0.9, wa=0.1)
-    @test angular_diameter_dist_mpc(c,1) ≈ 1612.0585 rtol = dist_rtol
+    @test angular_diameter_dist_mpc(c,1,rtol=dist_rtol) ≈ 1612.0585 rtol = dist_rtol
 end


### PR DESCRIPTION
`QuadGK.quadgk` accepts some optional keywords to control the integration.  This PR simply passes to `QuadGK.quadgk` any optional keyword provided to the functions.

Note: this is based on #15 