### PR TITLE
Fix, export and test `comoving_volume_element`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Distances
     <td>Comoving radial distance to redshift z, in Mpc</td>
   </tr>
   <tr>
+    <td>comoving_volume_element(cosmo,&nbsp;z)</td>
+    <td>Comoving volume element out to redshift z, in Gpc<sup>3</sup></td>
+  </tr>
+  <tr>
     <td>comoving_volume(cosmo,&nbsp;z)</td>
     <td>Comoving volume out to redshift z, in Gpc<sup>3</sup></td>
   </tr>

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -12,6 +12,7 @@ export cosmology,
        comoving_radial_dist,
        comoving_transverse_dist,
        comoving_volume,
+       comoving_volume_element,
        distmod,
        H,
        hubble_dist,
@@ -188,7 +189,7 @@ function comoving_volume(c::AbstractClosedCosmology, z; kws...)
 end
 
 comoving_volume_element(c::AbstractCosmology, z; kws...) =
-    hubble_dist0(c,z)*angular_diameter_dist(c,z; kws...)^2/a2E(c,scale_factor(z))
+    hubble_dist0(c)*angular_diameter_dist(c,z; kws...)^2/a2E(c,scale_factor(z))
 
 # times
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,20 @@
 using Cosmology
-using Test, Unitful, UnitfulAstro
+using Test, Unitful, UnitfulAstro, QuadGK
 
 # values from http://icosmos.co.uk/
 
 dist_rtol = 1e-6
 age_rtol = 2e-4
+# Integrating a unitful function would require UnitfulIntegration.jl.  Without using it, we
+# strip the units away from the integrand function
+integrand(c, z) = 4pi*ustrip(comoving_volume_element(c, z))
 
 @testset "FlatLCDM" begin
     c = cosmology(h=0.7, OmegaM=0.3, OmegaR=0)
     @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1651.9145u"Mpc" rtol = dist_rtol
     @test comoving_radial_dist(c,1,rtol=dist_rtol) ≈ 3303.829u"Mpc" rtol = dist_rtol
     @test comoving_volume(c,1,rtol=dist_rtol) ≈ 151.0571u"Gpc^3" rtol = dist_rtol
+    @test quadgk(z -> integrand(c, z), 0, 2.5)[1] ≈ ustrip(comoving_volume(c, 2.5))
     @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6607.6579u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.1002 rtol = dist_rtol
     @test age(c,0,rtol=age_rtol) ≈ 13.4694u"Gyr" rtol = age_rtol
@@ -23,6 +27,7 @@ end
     @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1619.9588u"Mpc" rtol = dist_rtol
     @test comoving_radial_dist(c,1,rtol=dist_rtol) ≈ 3209.784u"Mpc" rtol = dist_rtol
     @test comoving_volume(c,1,rtol=dist_rtol) ≈ 140.0856u"Gpc^3" rtol = dist_rtol
+    @test quadgk(z -> integrand(c, z), 0, 2.5)[1] ≈ ustrip(comoving_volume(c, 2.5))
     @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6479.8352u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.0578 rtol = dist_rtol
     @test age(c,0,rtol=age_rtol) ≈ 13.064u"Gyr" rtol = age_rtol
@@ -35,6 +40,7 @@ end
     @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1686.5272u"Mpc" rtol = dist_rtol
     @test comoving_radial_dist(c,1,rtol=dist_rtol) ≈ 3408.937u"Mpc" rtol = dist_rtol
     @test comoving_volume(c,1,rtol=dist_rtol) ≈ 163.8479u"Gpc^3" rtol = dist_rtol
+    @test quadgk(z -> integrand(c, z), 0, 2.5)[1] ≈ ustrip(comoving_volume(c, 2.5))
     @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6746.1088u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.1453 rtol = dist_rtol
     @test age(c,0,rtol=age_rtol) ≈ 13.925u"Gyr" rtol = age_rtol
@@ -47,6 +53,7 @@ end
     @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1612.0585u"Mpc" rtol = dist_rtol
     @test comoving_radial_dist(c,1,rtol=dist_rtol) ≈ 3224.1169u"Mpc" rtol = dist_rtol
     @test comoving_volume(c,1,rtol=dist_rtol) ≈ 140.3851u"Gpc^3" rtol = dist_rtol
+    @test quadgk(z -> integrand(c, z), 0, 2.5)[1] ≈ ustrip(comoving_volume(c, 2.5))
     @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6448.2338u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.0472 rtol = dist_rtol
     @test age(c,0,rtol=age_rtol) ≈ 13.1915u"Gyr" rtol = age_rtol
@@ -59,6 +66,7 @@ end
     @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1588.0181u"Mpc" rtol = dist_rtol
     @test comoving_radial_dist(c,rtol=dist_rtol,1) ≈ 3147.6227u"Mpc" rtol = dist_rtol
     @test comoving_volume(c,1,rtol=dist_rtol) ≈ 132.0466u"Gpc^3" rtol = dist_rtol
+    @test quadgk(z -> integrand(c, z), 0, 2.5)[1] ≈ ustrip(comoving_volume(c, 2.5))
     @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6352.0723u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.0146 rtol = dist_rtol
     @test age(c,0,rtol=age_rtol) ≈ 12.8488u"Gyr" rtol = age_rtol
@@ -71,6 +79,7 @@ end
     @test angular_diameter_dist(c,1,rtol=dist_rtol) ≈ 1637.5993u"Mpc" rtol = dist_rtol
     @test comoving_radial_dist(c,1,rtol=dist_rtol) ≈ 3307.9932u"Mpc" rtol = dist_rtol
     @test comoving_volume(c,1,rtol=dist_rtol) ≈ 149.8301u"Gpc^3" rtol = dist_rtol
+    @test quadgk(z -> integrand(c, z), 0, 2.5)[1] ≈ ustrip(comoving_volume(c, 2.5))
     @test luminosity_dist(c,1,rtol=dist_rtol) ≈ 6550.3973u"Mpc" rtol = dist_rtol
     @test distmod(c,1,rtol=dist_rtol) ≈ 44.0813 rtol = dist_rtol
     @test age(c,0,rtol=age_rtol) ≈ 13.5702u"Gyr" rtol = age_rtol


### PR DESCRIPTION
`comoving_volume_element` was not exported nor tested, probably because it was wrong, as it used to call a non existing function (`hubble_dist0(c,z)`).  This PR fixes this, export the function and test it by simply integrating it and comparing the result with `comoving_volume`.