### PR TITLE
Fix year not being exported by UnitfulAstro

### DIFF
--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -1,8 +1,8 @@
 module Cosmology
 
 using QuadGK, Unitful
-import Unitful: km, s
-using UnitfulAstro: Mpc, Gpc, Gyr
+import Unitful: km, s, Gyr
+using UnitfulAstro: Mpc, Gpc
 
 export cosmology,
        age,


### PR DESCRIPTION
Since [JuliaAstro/UnitfulAstro.jl/pull/22](https://github.com/JuliaAstro/UnitfulAstro.jl/pull/22) was included in the latest minor release of UnitfulAstro due to "year" being exported by Unitful, compiling Cosmology.jl now gives an error with the latest UnitfulAstro release (v1.1.0).
The fix is simply to import Gyr from Unitful instead of from UnitfulAstro.