### PR TITLE
Adjust factor used for hubble time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Cosmology"
 uuid = "76746363-e552-5dba-9a5a-cef6fa9cc5ab"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -172,7 +172,7 @@ H(c::AbstractCosmology, z) = 100 * c.h * E(c, z) * km / s / Mpc
 hubble_dist0(c::AbstractCosmology) = 2997.92458 / c.h * Mpc
 hubble_dist(c::AbstractCosmology, z) = hubble_dist0(c) / E(c, z)
 
-hubble_time0(c::AbstractCosmology) = 9.77814 / c.h * Gyr
+hubble_time0(c::AbstractCosmology) = 9.777922216807891 / c.h * Gyr
 hubble_time(c::AbstractCosmology, z) = hubble_time0(c) / E(c, z)
 
 # distances


### PR DESCRIPTION
I was not able to reproduce the current used value of 9.77814 for the computation of the hubble time (9.77814 / h * Gyr).
Instead, I believe it should be `1 / h / (100 km/s/Mpc) = 9.777922216807891 / h * Gyr`.

This can be obtained with `Unitful` and `UnitfulAstro`:

`a = ustrip(u"Gyr", 1/100u"km/s/Mpc")`

With this value, the factor used in the computation of `hubble_dist0` is also exactly recovered by multiplying the 9.7779... Gyr by the speed of light.