### PR TITLE
Fix doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,16 +40,3 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  Documentation:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: 1
-      - name: Cache artifacts
-        uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-docdeploy@releases/v1
-        env:
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
+          - "lts"
           - "1.0"
           - "1"
           - "nightly"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: Documentation
+
+on:
+  push:
+    branches: "master"
+    tags: ["*"]
+  pull_request:
+  release:
+
+jobs:
+  Build and deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1
+      - name: Cache artifacts
+        uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-docdeploy@releases/v1
+        env:
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,11 @@
 [deps]
+Cosmology = "76746363-e552-5dba-9a5a-cef6fa9cc5ab"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAstro = "6112ee07-acf9-5e0f-b108-d242c714bf9f"
 
 [compat]
 Documenter = "1"
+
+[sources.Cosmology]
+path = ".."

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAstro = "6112ee07-acf9-5e0f-b108-d242c714bf9f"
 
 [compat]
-Documenter = "0.24, 0.25, 0.26, 0.27, 1"
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,8 +16,8 @@ makedocs(;
         prettyurls = get(ENV, "CI", "false") == "true",
         canonical = "https://juliaastro.github.io/Cosmology.jl",
         assets = String[],
-   ),
-    pages=pages,
+    ),
+    pages,
 )
 
 deploydocs(;

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,7 +10,7 @@ end
 
 !!! tip "Unitful"
     [Unitful.jl](https://github.com/painterqubits/Unitful.jl) works seamlessly with Cosmology.jl. In order to use its features, make sure it is installed and imported, along with [UnitfulAstro](https://github.com/juliaastro/UnitfulAstro.jl).
-    ```julia
+    ```julia-repl
     pkg> add Unitful UnitfulAstro
     julia> using Unitful, UnitfulAstro
     ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,15 +4,6 @@ using Documenter
 
 @testset "Cosmology" begin
 
-    # Doctest is good for CI, but has variation in system to system. For now,
-    # only run on supported systems as a measure that the docs are reasonably
-    # accurate.
-    doctest_conds = Bool[Sys.islinux(), Sys.ARCH == :x86_64]
-    if all(doctest_conds)
-        DocMeta.setdocmeta!(Cosmology, :DocTestSetup, :(using Cosmology); recursive = true)
-        doctest(Cosmology)
-    end
-
     # values from http://icosmos.co.uk/
 
     dist_rtol = 1e-6


### PR DESCRIPTION
For now, move doctests back to the docs.yml workflow only, where it only runs on one architecture and julia setup. This serves as a check that the docs are reasonably accurate, but not that the code is covered. The code correctness is now squarely under runtests.jl.