### PR TITLE
Add docstrings for more methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,19 +3,21 @@ uuid = "76746363-e552-5dba-9a5a-cef6fa9cc5ab"
 version = "1.0.3"
 
 [deps]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAstro = "6112ee07-acf9-5e0f-b108-d242c714bf9f"
 
 [compat]
+DocStringExtensions = "0.9"
 QuadGK = "0.1.1, 0.2, 0.3, 2"
 Unitful = "1.2"
 UnitfulAstro = "1.1"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Documenter"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,11 +1,12 @@
 [deps]
 Cosmology = "76746363-e552-5dba-9a5a-cef6fa9cc5ab"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAstro = "6112ee07-acf9-5e0f-b108-d242c714bf9f"
 
+[sources]
+Cosmology = {path = ".."}
+
 [compat]
 Documenter = "1"
-
-[sources.Cosmology]
-path = ".."

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,11 +1,15 @@
-using Documenter
 using Cosmology
+using Documenter
 using Documenter.Remotes: GitHub
+using DocumenterCitations
 
 
 DocMeta.setdocmeta!(Cosmology, :DocTestSetup, :(using Cosmology); recursive = true)
 
 include("pages.jl")
+
+bib = CitationBibliography(
+    joinpath(@__DIR__, "src", "refs.bib"); style = :authoryear)
 
 makedocs(;
     modules = [Cosmology],
@@ -17,6 +21,7 @@ makedocs(;
         canonical = "https://juliaastro.github.io/Cosmology.jl",
         assets = String[],
     ),
+    plugins = [bib],
     pages,
 )
 

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,4 +1,5 @@
 pages = [
     "Home" => "index.md",
-    "API/Reference" => "api.md"
+    "API/Reference" => "api.md",
+    "Internals" => "internals.md",
 ]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -93,11 +93,3 @@ julia> lookback_time(u"yr", c, 1.2)
 8.761465604385489e9 yr
 ```
 
-## Misc
-```@docs
-H
-Cosmology.E
-Cosmology.Z
-Cosmology.a2E
-Cosmology.scale_factor
-```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -93,6 +93,11 @@ julia> lookback_time(u"yr", c, 1.2)
 8.761465604385489e9 yr
 ```
 
+## Miscellaneous
+```@docs
+H
+scale_factor
+```
 
 
 ## Bibliography

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -29,6 +29,7 @@ angular_diameter_dist
 comoving_radial_dist
 luminosity_dist
 distmod
+hubble_dist
 ```
 
 ### Examples
@@ -79,6 +80,7 @@ julia> comoving_volume(u"ly^3", c, 0.6)
 ```@docs
 age
 lookback_time
+hubble_time
 ```
 
 ### Examples

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -93,3 +93,9 @@ julia> lookback_time(u"yr", c, 1.2)
 8.761465604385489e9 yr
 ```
 
+
+
+## Bibliography
+```@bibliography
+Pages = ["api.md"]
+```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -92,3 +92,12 @@ julia> age(c, 1.2)
 julia> lookback_time(u"yr", c, 1.2)
 8.761465604385489e9 yr
 ```
+
+## Misc
+```@docs
+H
+Cosmology.E
+Cosmology.Z
+Cosmology.a2E
+Cosmology.scale_factor
+```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,0 +1,10 @@
+# Internals
+
+The following types and methods are internal, and should not be considered safe for public use.
+```@docs
+H
+Cosmology.E
+Cosmology.Z
+Cosmology.a2E
+Cosmology.scale_factor
+```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -2,11 +2,9 @@
 
 The following types and methods are internal, and should not be considered safe for public use.
 ```@docs
-H
 Cosmology.E
 Cosmology.Z
 Cosmology.a2E
-Cosmology.scale_factor
 
 ## Bibliography
 

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -5,6 +5,9 @@ The following types and methods are internal, and should not be considered safe 
 Cosmology.E
 Cosmology.Z
 Cosmology.a2E
+Cosmology.hubble_dist0
+Cosmology.hubble_time0
+```
 
 ## Bibliography
 

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -4,6 +4,16 @@ CurrentModule = Cosmology
 # Internals
 
 The following types and methods are internal, and should not be considered safe for public use.
+
+## Types
+```@docs
+AbstractCosmology
+FlatLCDM
+ClosedLCDM
+OpenLCDM
+```
+
+## Methods
 ```@docs
 E
 Z

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -7,4 +7,9 @@ Cosmology.E
 Cosmology.Z
 Cosmology.a2E
 Cosmology.scale_factor
+
+## Bibliography
+
+```@bibliography
+Pages = ["internals.md"]
 ```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -22,9 +22,3 @@ a2E(::Union{FlatWCDM,ClosedWCDM,OpenWCDM}, a)
 hubble_dist0
 hubble_time0
 ```
-
-## Bibliography
-
-```@bibliography
-Pages = ["internals.md"]
-```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,12 +1,16 @@
+```@meta
+CurrentModule = Cosmology
+```
 # Internals
 
 The following types and methods are internal, and should not be considered safe for public use.
 ```@docs
-Cosmology.E
-Cosmology.Z
-Cosmology.a2E
-Cosmology.hubble_dist0
-Cosmology.hubble_time0
+E
+Z
+a2E
+a2E(::Union{FlatWCDM,ClosedWCDM,OpenWCDM}, a)
+hubble_dist0
+hubble_time0
 ```
 
 ## Bibliography

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,0 +1,12 @@
+@book{schneider2015,
+  title = {Extragalactic Astronomy and Cosmology: An Introduction},
+  shorttitle = {Extragalactic Astronomy and Cosmology},
+  author = {Schneider, Peter},
+  year = {2015},
+  edition = {2nd},
+  publisher = {Springer},
+  address = {Berlin, Heidelberg},
+  doi = {10.1007/978-3-642-54083-7},
+  isbn = {978-3-642-54083-7},
+  keywords = {Astronomy,Astrophysics,Cosmology}
+}

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -1,6 +1,6 @@
 module Cosmology
 
-using QuadGK
+using QuadGK: quadgk
 using Unitful
 import Unitful: km, s, Gyr
 using UnitfulAstro: Mpc, Gpc
@@ -141,7 +141,7 @@ function cosmology(;h = 0.69,
                    OmegaR = nothing,
                    Tcmb = 2.7255,
                    w0 = -1,
-    wa = 0)
+                   wa = 0)
 
     if OmegaR === nothing
         OmegaG = 4.48131e-7 * Tcmb^4 / h^2
@@ -157,9 +157,9 @@ function cosmology(;h = 0.69,
 
     if OmegaK < 0
         return ClosedLCDM(h, OmegaK, OmegaL, OmegaM, OmegaR)
-        elseif OmegaK > 0
+    elseif OmegaK > 0
         return OpenLCDM(h, OmegaK, OmegaL, OmegaM, OmegaR)
-        else
+    else
         return FlatLCDM(h, OmegaL, OmegaM, OmegaR)
     end
 end
@@ -179,9 +179,9 @@ hubble_time(c::AbstractCosmology, z) = hubble_time0(c) / E(c, z)
 # distances
 
 Z(c::AbstractCosmology, z::Real, ::Nothing; kws...) =
-    QuadGK.quadgk(a->1 / a2E(c, a), scale_factor(z), 1; kws...)[1]
+    quadgk(a->1 / a2E(c, a), scale_factor(z), 1; kws...)[1]
 Z(c::AbstractCosmology, z₁::Real, z₂::Real; kws...) =
-    QuadGK.quadgk(a->1 / a2E(c, a), scale_factor(z₂), scale_factor(z₁); kws...)[1]
+    quadgk(a->1 / a2E(c, a), scale_factor(z₂), scale_factor(z₁); kws...)[1]
 
 comoving_radial_dist(c::AbstractCosmology, z₁, z₂ = nothing; kws...) = hubble_dist0(c) * Z(c, z₁, z₂; kws...)
 
@@ -271,7 +271,7 @@ comoving_volume_element(c::AbstractCosmology, z; kws...) =
 
 # times
 
-T(c::AbstractCosmology, a0, a1; kws...) = QuadGK.quadgk(x->x / a2E(c, x), a0, a1; kws...)[1]
+T(c::AbstractCosmology, a0, a1; kws...) = quadgk(x->x / a2E(c, x), a0, a1; kws...)[1]
 
 """
     age([u::Unitlike,] c::AbstractCosmology, z)

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -34,9 +34,6 @@ end
 FlatLCDM(h::Real, Ω_Λ::Real, Ω_m::Real, Ω_r::Real) =
     FlatLCDM(promote(float(h), float(Ω_Λ), float(Ω_m), float(Ω_r))...)
 
-
-a2E(c::FlatLCDM, a) = sqrt(c.Ω_r + c.Ω_m * a + c.Ω_Λ * a^4)
-
 struct ClosedLCDM{T <: Real} <: AbstractClosedCosmology
     h::T
     Ω_k::T
@@ -59,11 +56,6 @@ OpenLCDM(h::Real, Ω_k::Real, Ω_Λ::Real, Ω_m::Real, Ω_r::Real) =
     OpenLCDM(promote(float(h), float(Ω_k), float(Ω_Λ), float(Ω_m),
                      float(Ω_r))...)
 
-
-function a2E(c::Union{ClosedLCDM,OpenLCDM}, a)
-    a2 = a * a
-    sqrt(c.Ω_r + c.Ω_m * a + (c.Ω_k + c.Ω_Λ * a2) * a2)
-end
 
 for c in ("Flat", "Open", "Closed")
     name = Symbol("$(c)WCDM")
@@ -95,7 +87,13 @@ function WCDM(h::Real, Ω_k::Real, Ω_Λ::Real, Ω_m::Real, Ω_r::Real, w0::Real
     end
 end
 
+a2E(c::FlatLCDM, a) = sqrt(c.Ω_r + c.Ω_m * a + c.Ω_Λ * a^4)
+function a2E(c::Union{ClosedLCDM,OpenLCDM}, a)
+    a2 = a * a
+    sqrt(c.Ω_r + c.Ω_m * a + (c.Ω_k + c.Ω_Λ * a2) * a2)
+end
 function a2E(c::Union{FlatWCDM,ClosedWCDM,OpenWCDM}, a)
+    # dark energy scale factor
     ade = exp((1 - 3 * (c.w0 + c.wa)) * log(a) + 3 * c.wa * (a - 1))
     sqrt(c.Ω_r + (c.Ω_m + c.Ω_k * a) * a + c.Ω_Λ * ade)
 end

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -4,6 +4,7 @@ using QuadGK: quadgk
 using Unitful
 import Unitful: km, s, Gyr
 using UnitfulAstro: Mpc, Gpc
+using DocStringExtensions
 
 export cosmology,
        age,
@@ -20,11 +21,21 @@ export cosmology,
        lookback_time,
        scale_factor
 
+"""
+$(TYPEDEF)
+
+Abstract supertype for all cosmological models.
+"""
 abstract type AbstractCosmology end
 abstract type AbstractClosedCosmology <: AbstractCosmology end
 abstract type AbstractFlatCosmology <: AbstractCosmology end
 abstract type AbstractOpenCosmology <: AbstractCosmology end
 
+"""
+$(TYPEDEF)
+
+ΛCDM model of the universe with ``Ω_k = 0``.
+"""
 struct FlatLCDM{T <: Real} <: AbstractFlatCosmology
     h::T
     Ω_Λ::T
@@ -34,6 +45,11 @@ end
 FlatLCDM(h::Real, Ω_Λ::Real, Ω_m::Real, Ω_r::Real) =
     FlatLCDM(promote(float(h), float(Ω_Λ), float(Ω_m), float(Ω_r))...)
 
+"""
+$(TYPEDEF)
+
+ΛCDM model of the universe with ``Ω_k < 0``.
+"""
 struct ClosedLCDM{T <: Real} <: AbstractClosedCosmology
     h::T
     Ω_k::T
@@ -45,6 +61,11 @@ ClosedLCDM(h::Real, Ω_k::Real, Ω_Λ::Real, Ω_m::Real, Ω_r::Real) =
     ClosedLCDM(promote(float(h), float(Ω_k), float(Ω_Λ), float(Ω_m),
                        float(Ω_r))...)
 
+"""
+$(TYPEDEF)
+
+ΛCDM model of the universe with ``Ω_k > 0``.
+"""
 struct OpenLCDM{T <: Real} <: AbstractOpenCosmology
     h::T
     Ω_k::T

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -214,10 +214,6 @@ E(c::AbstractCosmology, z) = (a = scale_factor(z); a2E(c, a) / a^2)
     H(c::AbstractCosmology, z)
 
 Hubble parameter at redshift `z`.
-
-```math
-H(z) = (100\\mathrm{km/s/Mpc}) h E(z)
-```
 """
 H(c::AbstractCosmology, z) = 100 * c.h * E(c, z) * km / s / Mpc
 
@@ -271,7 +267,9 @@ Z(c::AbstractCosmology, z₁::Real, z₂::Real; kws...) =
     Z(c::AbstractCosmology, z, nothing; kws...)
     Z(c::AbstractCosmology, z₁, z₂; kws...)
 
-TODO
+TODO (Internal helper function for comoving distances)
+
+If `nothing` is used for the upper bound of integration, it defaults to `z₂ = 0`.
 
 Mathematical definition:
 ```math

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -98,12 +98,26 @@ function a2E(c::Union{FlatWCDM,ClosedWCDM,OpenWCDM}, a)
     ade = exp((1 - 3 * (c.w0 + c.wa)) * log(a) + 3 * c.wa * (a - 1))
     sqrt(c.Ω_r + (c.Ω_m + c.Ω_k * a) * a + c.Ω_Λ * ade)
 end
-"""
+@doc raw"""
     a2E(c::AbstractCosmology, a)
 
 
 Calculates the intermediate quantity ``a^2 E(a)``.
 This is an internal function used to simplify computation.
+
+Mathematical formulation (for LCDM models):
+```math
+a^2 E(a) = \begin{cases}
+\sqrt{Ω_r + Ω_m a + Ω_Λ a^4} & \text{if flat} \\
+\sqrt{Ω_r + Ω_m a + (Ω_k + Ω_Λ a^2) a^2} & \text{otherwise}
+\end{cases}
+```
+
+Mathematical formulation (for WCDM models):
+```math
+a^2 E(a) = \sqrt{Ω_r + (Ω_m + Ω_k a) a + Ω_Λ a_{de}}
+```
+where ``a_{de} = \exp[(1 - 3 w_0 - 3 w_a) \log(a) + 3 w_a (a - 1)]``
 """
 a2E
 
@@ -177,32 +191,22 @@ end
     scale_factor(z)
 
 Return the scale factor ``a(t)`` for a given redshift ``z(t)``. According to
-the FLRW metric it's given as ``a = 1/(1 + z)``.
+the [Friedmann–Lemaître–Robertson–Walker metric](https://en.wikipedia.org/wiki/Friedmann–Lemaître–Robertson–Walker_metric) it's given as ``a = 1/(1 + z)``
+([Schneider 2015, p. 186](@cite schneider2015)).
+
+A scale factor of 1, i.e., a redshift of 0, refers to the present epoch.
 """
 scale_factor(z) = 1 / (1 + z)
 
 @doc raw"""
     E(c::AbstractCosmology, z)
 
-Dimensionless Hubble parameter ``E(z)`` at redshift `z`. It's defined as
+Dimensionless Hubble function ``E(z)`` at redshift `z`. It's defined as
 ```math
-E(z) ≡ \frac{H(z)}{(100\mathrm{km/s/Mpc}) h}
+E(z) ≡ \frac{H(z)}{H_0} = \frac{H(z)}{(100\mathrm{km/s/Mpc}) h}
 ```
-where ``a = 1/(1+z)``.
-
-Mathematical formulation (for LCDM models):
-```math
-a^2 E(a) = \begin{cases}
-\sqrt{Ω_r + Ω_m a + Ω_Λ a^4} & \text{if flat} \\
-\sqrt{Ω_r + Ω_m a + (Ω_k + Ω_Λ a^2) a^2} & \text{otherwise}
-\end{cases}
-```
-
-Mathematical formulation (for WCDM models):
-```math
-a^2 E(a) = \sqrt{Ω_r + (Ω_m + Ω_k a) a + Ω_Λ a_{de}}
-```
-where ``a_{de} = \exp((1 - 3 w_0 - 3 w_a) \log(a) + 3 w_a (a - 1))``
+where ``H_0 = H(z=0)`` is the Hubble parameter at the present epoch
+([Schneider 2015, p. 183](@cite schneider2015)).
 """
 E(c::AbstractCosmology, z) = (a = scale_factor(z); a2E(c, a) / a^2)
 

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -273,12 +273,9 @@ If `nothing` is used for the upper bound of integration, it defaults to `z₂ = 
 
 Mathematical definition:
 ```math
-Z = \int_{1/(1+z)}^1 \frac{1}{a^2 E(a)} da
+Z = \int_{a_1}^{a_2} \frac{1}{a^2 E(a)} da
 ```
-or
-```math
-Z = \int_{1/(1+z_2)}^{1/(1+z_1)} \frac{1}{a^2 E(a)} da
-```
+where ``a_1 = 1/(1+z_1)`` and ``a_2 = 1/(1+z_2)``.
 """
 Z
 

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -217,10 +217,44 @@ H(z) = (100\\mathrm{km/s/Mpc}) h E(z)
 """
 H(c::AbstractCosmology, z) = 100 * c.h * E(c, z) * km / s / Mpc
 
+"""
+    hubble_dist0(c::AbstractCosmology)
+
+Hubble distance at redshift 0.
+
+### See also
+[`hubble_dist`](@ref)
+"""
 hubble_dist0(c::AbstractCosmology) = 2997.92458 / c.h * Mpc
+"""
+    hubble_dist(c::AbstractCosmology, z)
+
+Hubble distance, defined as the product of the speed of light and the Hubble parameter.
+That is, ``c / H(z)``
+
+### See also
+[`hubble_time`](@ref)
+"""
 hubble_dist(c::AbstractCosmology, z) = hubble_dist0(c) / E(c, z)
 
+"""
+    hubble_time0(c::AbstractCosmology)
+
+Hubble time at redshift 0.
+
+### See also
+[`hubble_time`](@ref)
+"""
 hubble_time0(c::AbstractCosmology) = 9.777922216807891 / c.h * Gyr
+"""
+    hubble_time(c::AbstractCosmology, z)
+
+Hubble time, defined as the inverse of the Hubble parameter. That is,
+``t_H(z) = 1/H(z)``
+
+### See also
+[`hubble_dist`](@ref)
+"""
 hubble_time(c::AbstractCosmology, z) = hubble_time0(c) / E(c, z)
 
 # distances

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -205,6 +205,7 @@ a^2 E(a) = \sqrt{Ω_r + (Ω_m + Ω_k a) a + Ω_Λ a_{de}}
 where ``a_{de} = \exp((1 - 3 w_0 - 3 w_a) \log(a) + 3 w_a (a - 1))``
 """
 E(c::AbstractCosmology, z) = (a = scale_factor(z); a2E(c, a) / a^2)
+
 """
     H(c::AbstractCosmology, z)
 

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -98,6 +98,15 @@ function a2E(c::Union{FlatWCDM,ClosedWCDM,OpenWCDM}, a)
     ade = exp((1 - 3 * (c.w0 + c.wa)) * log(a) + 3 * c.wa * (a - 1))
     sqrt(c.Ω_r + (c.Ω_m + c.Ω_k * a) * a + c.Ω_Λ * ade)
 end
+"""
+    a2E(c::AbstractCosmology, a)
+
+
+Calculates the intermediate quantity ``a^2 E(a)``.
+This is an internal function used to simplify computation.
+"""
+a2E
+
 
 """
     cosmology(;h = 0.69,
@@ -171,6 +180,30 @@ Return the scale factor ``a(t)`` for a given redshift ``z(t)``. According to
 the FLRW metric it's given as ``a = 1/(1 + z)``.
 """
 scale_factor(z) = 1 / (1 + z)
+
+@doc raw"""
+    E(c::AbstractCosmology, z)
+
+Dimensionless Hubble parameter ``E(z)`` at redshift `z`. It's defined as
+```math
+E(z) ≡ \frac{H(z)}{(100\mathrm{km/s/Mpc}) h}
+```
+where ``a = 1/(1+z)``.
+
+Mathematical formulation (for LCDM models):
+```math
+a^2 E(a) = \begin{cases}
+\sqrt{Ω_r + Ω_m a + Ω_Λ a^4} & \text{if flat} \\
+\sqrt{Ω_r + Ω_m a + (Ω_k + Ω_Λ a^2) a^2} & \text{otherwise}
+\end{cases}
+```
+
+Mathematical formulation (for WCDM models):
+```math
+a^2 E(a) = \sqrt{Ω_r + (Ω_m + Ω_k a) a + Ω_Λ a_{de}}
+```
+where ``a_{de} = \exp((1 - 3 w_0 - 3 w_a) \log(a) + 3 w_a (a - 1))``
+"""
 E(c::AbstractCosmology, z) = (a = scale_factor(z); a2E(c, a) / a^2)
 """
     H(c::AbstractCosmology, z)

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -311,12 +311,15 @@ Z
 
 comoving_radial_dist(c::AbstractCosmology, z₁, z₂ = nothing; kws...) = hubble_dist0(c) * Z(c, z₁, z₂; kws...)
 
-"""
+@doc raw"""
     comoving_radial_dist([u::Unitlike,] c::AbstractCosmology, [z₁,] z₂)
 
-Comoving radial distance in Mpc at redshift `z₂` as seen by an observer at `z₁`.
+Comoving radial distance (``D_C``) in Mpc at redshift `z₂` as seen by an observer at `z₁`.
 Redshift `z₁` defaults to 0 if omitted.  Will convert to compatible unit `u` if
 provided.
+
+It's calculated as ``D_C = D_{H0} Z``, where ``D_{H0}`` is the Hubble distance at
+the present epoch and, ``Z = \int_{z_1}^{z_2} \frac{dz}{E(z)}``.
 """
 comoving_radial_dist
 

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -48,7 +48,6 @@ ClosedLCDM(h::Real, Ω_k::Real, Ω_Λ::Real, Ω_m::Real, Ω_r::Real) =
     ClosedLCDM(promote(float(h), float(Ω_k), float(Ω_Λ), float(Ω_m),
                        float(Ω_r))...)
 
-
 struct OpenLCDM{T <: Real} <: AbstractOpenCosmology
     h::T
     Ω_k::T
@@ -166,8 +165,23 @@ end
 
 # hubble rate
 
+"""
+    scale_factor(z)
+
+Return the scale factor ``a(t)`` for a given redshift ``z(t)``. According to
+the FLRW metric it's given as ``a = 1/(1 + z)``.
+"""
 scale_factor(z) = 1 / (1 + z)
 E(c::AbstractCosmology, z) = (a = scale_factor(z); a2E(c, a) / a^2)
+"""
+    H(c::AbstractCosmology, z)
+
+Hubble parameter at redshift `z`.
+
+```math
+H(z) = (100\\mathrm{km/s/Mpc}) h E(z)
+```
+"""
 H(c::AbstractCosmology, z) = 100 * c.h * E(c, z) * km / s / Mpc
 
 hubble_dist0(c::AbstractCosmology) = 2997.92458 / c.h * Mpc

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -114,11 +114,11 @@ end
 
 # Parameters
 * `h` - Dimensionless Hubble constant
+* `Neff` - Effective number of massless neutrino species; used to compute Ω_ν
 * `OmegaK` - Curvature density (Ω_k)
 * `OmegaM` - Matter density (Ω_m)
 * `OmegaR` - Radiation density (Ω_r)
 * `Tcmb` - CMB temperature in Kelvin; used to compute Ω_γ
-* `Neff` - Effective number of massless neutrino species; used to compute Ω_ν
 * `w0` - CPL dark energy equation of state; `w = w0 + wa(1-a)`
 * `wa` - CPL dark energy equation of state; `w = w0 + wa(1-a)`
 

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -57,6 +57,7 @@ OpenLCDM(h::Real, Ω_k::Real, Ω_Λ::Real, Ω_m::Real, Ω_r::Real) =
                      float(Ω_r))...)
 
 
+# define WCDM models, which includes a cosmological equation of state parameter w.
 for c in ("Flat", "Open", "Closed")
     name = Symbol("$(c)WCDM")
     @eval begin

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -93,33 +93,35 @@ function a2E(c::Union{ClosedLCDM,OpenLCDM}, a)
     a2 = a * a
     sqrt(c.Ω_r + c.Ω_m * a + (c.Ω_k + c.Ω_Λ * a2) * a2)
 end
-function a2E(c::Union{FlatWCDM,ClosedWCDM,OpenWCDM}, a)
-    # dark energy scale factor
-    ade = exp((1 - 3 * (c.w0 + c.wa)) * log(a) + 3 * c.wa * (a - 1))
-    sqrt(c.Ω_r + (c.Ω_m + c.Ω_k * a) * a + c.Ω_Λ * ade)
-end
 @doc raw"""
-    a2E(c::AbstractCosmology, a)
+    a2E(c::Union{FlatLCDM,ClosedLCDM,OpenLCDM}, a)
 
 
 Calculates the intermediate quantity ``a^2 E(a)``.
 This is an internal function used to simplify computation.
 
-Mathematical formulation (for LCDM models):
+Mathematical formulation (for ΛCDM models):
 ```math
-a^2 E(a) = \begin{cases}
-\sqrt{Ω_r + Ω_m a + Ω_Λ a^4} & \text{if flat} \\
-\sqrt{Ω_r + Ω_m a + (Ω_k + Ω_Λ a^2) a^2} & \text{otherwise}
-\end{cases}
+a^2 E(a) = \sqrt{Ω_r + Ω_m a + Ω_k a^2 + Ω_Λ a^4}
 ```
+where ``Ω_k = 0`` for a flat cosmological model.
+"""
+a2E
+
+@doc raw"""
+    a2E(c::Union{FlatWCDM,ClosedWCDM,OpenWCDM}, a)
 
 Mathematical formulation (for WCDM models):
 ```math
-a^2 E(a) = \sqrt{Ω_r + (Ω_m + Ω_k a) a + Ω_Λ a_{de}}
+a^2 E(a) = \sqrt{Ω_r + Ω_m a + Ω_k a^2 + Ω_Λ a_{de}}
 ```
 where ``a_{de} = \exp[(1 - 3 w_0 - 3 w_a) \log(a) + 3 w_a (a - 1)]``
 """
-a2E
+function a2E(c::Union{FlatWCDM,ClosedWCDM,OpenWCDM}, a)
+    # dark energy scale factor
+    ade = exp((1 - 3 * (c.w0 + c.wa)) * log(a) + 3 * c.wa * (a - 1))
+    sqrt(c.Ω_r + (c.Ω_m + c.Ω_k * a) * a + c.Ω_Λ * ade)
+end
 
 
 """
@@ -190,8 +192,8 @@ end
 """
     scale_factor(z)
 
-Return the scale factor ``a(t)`` for a given redshift ``z(t)``. According to
-the [Friedmann–Lemaître–Robertson–Walker metric](https://en.wikipedia.org/wiki/Friedmann–Lemaître–Robertson–Walker_metric)
+Return the scale factor ``a(t)`` for a given redshift ``z(t)``. According to the
+[Friedmann–Lemaître–Robertson–Walker metric](https://en.wikipedia.org/wiki/Friedmann–Lemaître–Robertson–Walker_metric)
 it's given as ``a = 1/(1 + z)`` ([Schneider 2015, p. 186](@cite schneider2015)).
 
 A scale factor of 1, i.e., a redshift of 0, refers to the present epoch.

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -121,7 +121,7 @@ end
 Calculates the intermediate quantity ``a^2 E(a)``.
 This is an internal function used to simplify computation.
 
-Mathematical formulation (for ΛCDM models):
+Mathematical definition (for ΛCDM models):
 ```math
 a^2 E(a) = \sqrt{Ω_r + Ω_m a + Ω_k a^2 + Ω_Λ a^4}
 ```
@@ -132,11 +132,13 @@ a2E
 @doc raw"""
     a2E(c::Union{FlatWCDM,ClosedWCDM,OpenWCDM}, a)
 
-Mathematical formulation (for WCDM models):
+The implementation of ``a^2 E(a)`` for WCDM models.
+
+Mathematical definition (for WCDM models):
 ```math
 a^2 E(a) = \sqrt{Ω_r + Ω_m a + Ω_k a^2 + Ω_Λ a_{de}}
 ```
-where ``a_{de} = \exp[(1 - 3 w_0 - 3 w_a) \log(a) + 3 w_a (a - 1)]``
+where ``a_{de} = \exp[(1 - 3 w_0 - 3 w_a) \log(a) + 3 w_a (a - 1)]``.
 """
 function a2E(c::Union{FlatWCDM,ClosedWCDM,OpenWCDM}, a)
     # dark energy scale factor
@@ -273,7 +275,7 @@ hubble_time0(c::AbstractCosmology) = 9.777922216807891 / c.h * Gyr
     hubble_time(c::AbstractCosmology, z)
 
 Hubble time, defined as the inverse of the Hubble parameter. That is,
-``t_H(z) = 1/H(z)``
+``t_H(z) = 1/H(z)``.
 
 ### See also
 [`hubble_dist`](@ref)

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -254,8 +254,8 @@ hubble_dist0(c::AbstractCosmology) = 2997.92458 / c.h * Mpc
 """
     hubble_dist(c::AbstractCosmology, z)
 
-Hubble distance, defined as the product of the speed of light and the Hubble parameter.
-That is, ``c / H(z)``
+Hubble distance ``D_H``, defined as the product of the speed of light and
+the Hubble time. That is, ``D_H(z) = c / H(z)``.
 
 ### See also
 [`hubble_time`](@ref)

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -109,14 +109,14 @@ a2E
 
 
 """
-    cosmology(;h = 0.69,
-               Neff = 3.04,
-               OmegaK = 0,
-               OmegaM = 0.29,
-               OmegaR = nothing,
-               Tcmb = 2.7255,
-               w0 = -1,
-               wa = 0)
+    cosmology(; h = 0.69,
+                Neff = 3.04,
+                OmegaK = 0,
+                OmegaM = 0.29,
+                OmegaR = nothing,
+                Tcmb = 2.7255,
+                w0 = -1,
+                wa = 0)
 
 
 # Parameters

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -228,6 +228,22 @@ Z(c::AbstractCosmology, z::Real, ::Nothing; kws...) =
     quadgk(a->1 / a2E(c, a), scale_factor(z), 1; kws...)[1]
 Z(c::AbstractCosmology, z₁::Real, z₂::Real; kws...) =
     quadgk(a->1 / a2E(c, a), scale_factor(z₂), scale_factor(z₁); kws...)[1]
+@doc raw"""
+    Z(c::AbstractCosmology, z, nothing; kws...)
+    Z(c::AbstractCosmology, z₁, z₂; kws...)
+
+TODO
+
+Mathematical definition:
+```math
+Z = \int_{1/(1+z)}^1 \frac{1}{a^2 E(a)} da
+```
+or
+```math
+Z = \int_{1/(1+z_2)}^{1/(1+z_1)} \frac{1}{a^2 E(a)} da
+```
+"""
+Z
 
 comoving_radial_dist(c::AbstractCosmology, z₁, z₂ = nothing; kws...) = hubble_dist0(c) * Z(c, z₁, z₂; kws...)
 

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -292,15 +292,20 @@ Z(c::AbstractCosmology, z₁::Real, z₂::Real; kws...) =
     Z(c::AbstractCosmology, z, nothing; kws...)
     Z(c::AbstractCosmology, z₁, z₂; kws...)
 
-TODO (Internal helper function for comoving distances)
+The line-of-sight comoving distance contributions for comoving radial distance.
 
-If `nothing` is used for the upper bound of integration, it defaults to `z₂ = 0`.
-
-Mathematical definition:
+It performs the integral
 ```math
-Z = \int_{a_1}^{a_2} \frac{1}{a^2 E(a)} da
+Z = \int_{z_1}^{z_2} \frac{dz}{E(z)} = \int_{a_2}^{a_1} \frac{da}{a^2 E(a)}
 ```
-where ``a_1 = 1/(1+z_1)`` and ``a_2 = 1/(1+z_2)``.
+where we can perform a change of variables with ``a = 1/(1+z)``,
+and ``dz = -da/a^2``.
+
+If `nothing` is used for the second bound of integration, it defaults
+to `z₁ = 0` (i.e., `a₁ = 1`).
+
+### See also
+[`comoving_radial_dist`](@ref)
 """
 Z
 

--- a/src/Cosmology.jl
+++ b/src/Cosmology.jl
@@ -191,8 +191,8 @@ end
     scale_factor(z)
 
 Return the scale factor ``a(t)`` for a given redshift ``z(t)``. According to
-the [Friedmann–Lemaître–Robertson–Walker metric](https://en.wikipedia.org/wiki/Friedmann–Lemaître–Robertson–Walker_metric) it's given as ``a = 1/(1 + z)``
-([Schneider 2015, p. 186](@cite schneider2015)).
+the [Friedmann–Lemaître–Robertson–Walker metric](https://en.wikipedia.org/wiki/Friedmann–Lemaître–Robertson–Walker_metric)
+it's given as ``a = 1/(1 + z)`` ([Schneider 2015, p. 186](@cite schneider2015)).
 
 A scale factor of 1, i.e., a redshift of 0, refers to the present epoch.
 """


### PR DESCRIPTION
- Add docstrings for ΛCDM types, `a2E`, `scale_factor`, `E`, `H`, `hubble_dist`, `hubble_time` (and their present counterparts), `Z`
- Add project dependency on DocStringExtensions
- Add docs dependency on DocumenterCitations
  - Add citations for some of the code used
- Add new page for internals, so that it can serve as an easy reference for package devs